### PR TITLE
streamlit 1.51.0

### DIFF
--- a/app_pages/1_View_&_Join_Base.py
+++ b/app_pages/1_View_&_Join_Base.py
@@ -176,7 +176,7 @@ def display_table_proposition(section_name, table_proposition: TableProposition)
         ):
             dialog_edit_table_proposition(table_proposition)
         # FAKE SPACE ON THE RIGHT
-        stu.fake_space_for_horizontal_container()
+        st.space("stretch")
 
 def view_table_propositions():
     for proposition in st.session_state.propositions:
@@ -312,7 +312,7 @@ def create_view_and_join_page():
                                  f"overlap] with **\"{warning_right.game_name}\"** (ID {warning_right.table_id})")
                         stu.render_overlaps_table_buttons(warning_left, warning_right, "warn")
         # FAKE SPACE ON THE RIGHT
-        stu.fake_space_for_horizontal_container(number=2)
+        st.space("stretch")
 
     # show propositions
     if len(st.session_state.propositions) == 0:
@@ -326,4 +326,5 @@ def create_view_and_join_page():
         else:
             dataframe_table_propositions()
 
+    st.divider()
     stu.add_powered_by_bgg_image()

--- a/app_pages/1_View_&_Join_Base.py
+++ b/app_pages/1_View_&_Join_Base.py
@@ -187,7 +187,7 @@ def timeline_table_propositions():
     df = stu.table_propositions_to_df(add_group=True, add_status=True, add_start_and_end_date=True)
 
     chart = timeline_chart(df)
-    selected_data = st.altair_chart(chart, use_container_width=True, on_select="rerun", theme=None)
+    selected_data = st.altair_chart(chart, width='stretch', on_select="rerun", theme=None)
 
     st.subheader("Selected item")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.50.0
+streamlit==1.51.0
 Authlib==1.3.2
 requests==2.32.3
 psycopg2-binary==2.9.10

--- a/utils/streamlit_utils.py
+++ b/utils/streamlit_utils.py
@@ -108,11 +108,6 @@ def str_to_bool(s: str) -> bool:
     """
     return str(s).lower() == 'true'
 
-def fake_space_for_horizontal_container(number=1):
-    for _ in range(number):
-        with st.container():
-            st.empty()
-
 def refresh_table_propositions(reason, **kwargs):
     """
     Refresh the table propositions in the session state


### PR DESCRIPTION
streamlit 1.51.0:
 - default UNmarked filter not visible bug fixed)
 - replacing custom space to st.space
 - replaced "use_container_width" with "width='stretch'" (deprecated)